### PR TITLE
Add more context options

### DIFF
--- a/[Config] Zen Context Menu/chrome.css
+++ b/[Config] Zen Context Menu/chrome.css
@@ -138,3 +138,21 @@
     display: none !important;
   }
 }
+/* Hide "New Tab", "Move Tab", "Close Tab", "Close Duplicate Tabs", "Close Multiple Tabs", "Reopen Closed Tab" options */
+@media (-moz-bool-pref: "uc.hidecontext.tabMovement") {
+  #context_openANewTab,
+  #context_moveTabOptions,
+  #context_closeTab,
+  #context_closeDuplicateTabs,
+  #context_closeTabOptions,
+  #context_undoCloseTab,
+  #menuseparator:nth-child(26) { /* Broken */
+    display: none !important
+  }
+}
+/* Hide Zen's "Split Tab" context options */
+@media (-moz-bool-pref: "uc.hidecontext.zenSplitTab") {
+  #context_zenSplitTabs {
+    display: none !important
+  }
+}

--- a/[Config] Zen Context Menu/preference.json
+++ b/[Config] Zen Context Menu/preference.json
@@ -70,6 +70,11 @@
     "type": "checkbox"
   },
   {
+    "property": "uc.hidecontext.zenSplitTab",
+    "label": "Hide 'Split Tab'",
+    "type": "checkbox"
+  },
+  {
     "property": "uc.hidecontext.inspect",
     "label": "Hide 'View Page Source' and 'Inspect' options",
     "type": "checkbox"
@@ -82,6 +87,11 @@
   {
     "property": "uc.hidecontext.screenshot",
     "label": "Hide 'Take Screenshot' option",
+    "type": "checkbox"
+  },
+  {
+    "property": "uc.hidecontext.tabMovement",
+    "label": "Hide 'New Tab', 'Move Tab', 'Close Tab', 'Close Duplicate Tabs', 'Close Multiple Tabs', 'Reopen Closed Tab'",
     "type": "checkbox"
   }
 ]


### PR DESCRIPTION
> [!WARNING] 
> This isn't ready to be merged. Menu separators are still not hidden correctly and I can't seem to get the CSS selector right. Any help would be greatly appreciated
![image](https://github.com/user-attachments/assets/850289c4-d658-48e8-8fc6-423d4738a086)


Added new context options:
- Hide 'New Tab', 'Move Tab', 'Close Tab', 'Close Duplicate Tabs', 'Close Multiple Tabs', 'Reopen Closed Tab'
- Hide 'Split Tab'