### PR TITLE
Fix zen mod links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 
 ## Config Themes
-- [**Zen Back Forward**](https://zen-browser.app/themes/c8d9e6e6-e702-4e15-8972-3596e57cf398)
+- [**Zen Back Forward**](https://zen-browser.app/mods/c8d9e6e6-e702-4e15-8972-3596e57cf398)
 
 ![Zen Back Forward Mod thumbnail](https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c8d9e6e6-e702-4e15-8972-3596e57cf398/image.png)
 
-- [**Cleaner Extension Menu**](https://zen-browser.app/themes/1e86cf37-a127-4f24-b919-d265b5ce29a0)
+- [**Cleaner Extension Menu**](https://zen-browser.app/mods/1e86cf37-a127-4f24-b919-d265b5ce29a0)
 
 ![Cleaner Extension Menu Mod thumbnail](https://github.com/user-attachments/assets/aac56b8f-9152-455d-a651-0bc20629fa5f)
 
-- [**Zen Context Menu**](https://zen-browser.app/themes/81fcd6b3-f014-4796-988f-6c3cb3874db8) | [Repo](https://github.com/zen-browser/theme-store/tree/main/themes/81fcd6b3-f014-4796-988f-6c3cb3874db8)
+- [**Zen Context Menu**](https://zen-browser.app/mods/81fcd6b3-f014-4796-988f-6c3cb3874db8) | [Repo](https://github.com/zen-browser/theme-store/tree/main/themes/81fcd6b3-f014-4796-988f-6c3cb3874db8)
 
 ![image](https://github.com/user-attachments/assets/43ea5089-7703-486e-8c78-d06d3ff8d459)
 
@@ -25,6 +25,6 @@
 ![Side Panels Config Mod prototype](https://github.com/user-attachments/assets/6766dff7-ec4e-4671-8f0c-86478f103695)
 
 ## Color Themes (Deprecated)
-- [**Matcha**](https://zen-browser.app/themes/80112b28-39e0-407c-8988-2290bc973b97)
+- [**Matcha**](https://zen-browser.app/mods/80112b28-39e0-407c-8988-2290bc973b97)
 
 ![Matcha Color Theme thumbnail](https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/80112b28-39e0-407c-8988-2290bc973b97/image.png)


### PR DESCRIPTION
The links to the Zen mods store were outdated and lead to a 404 page

Changed all links in the readme from zen-browser.app/**themes** to zen-browser.app/**mods**